### PR TITLE
Add support for setting dmenu path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ clipboard.
 $ bitwarden-dmenu --help
 Usage: bitwarden-dmenu [options]
 
+The DMENU_PATH environment variable can be used to point to an alternative dmenu implementation. Defaults to 'dmenu'.
+
 Options:
   --clear-clipboard   Number of seconds to keep selected field in the clipboard.
                       Defaults to 15s.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,8 @@ if (args.help) {
   console.log(
     `Usage: bitwarden-dmenu [options]
 
+The DMENU_PATH environment variable can be used to point to an alternative dmenu implementation. Defaults to 'dmenu'.
+
 Options:
   --clear-clipboard   Number of seconds to keep selected field in the clipboard.
                       Defaults to ${cachePasswordDefault}s.

--- a/src/exec-dmenu.js
+++ b/src/exec-dmenu.js
@@ -5,7 +5,6 @@ const dmenuPath = process.env.DMENU_PATH || 'dmenu'
 module.exports = (...args) => choices =>
   new Promise((resolve, reject) => {
     let choice = ''
-    let dmenu_path = process.env.DMENU_PATH
     const error = []
 
     // Use a default of 'dmenu' if not specified in process.env

--- a/src/exec-dmenu.js
+++ b/src/exec-dmenu.js
@@ -1,5 +1,7 @@
 const { exec } = require('child_process')
 
+const dmenuPath = process.env.DMENU_PATH || 'dmenu'
+
 module.exports = (...args) => choices =>
   new Promise((resolve, reject) => {
     let choice = ''
@@ -7,8 +9,7 @@ module.exports = (...args) => choices =>
     const error = []
 
     // Use a default of 'dmenu' if not specified in process.env
-    const dmenu_binary = (typeof dmenu_path === 'undefined') ? 'dmenu' : dmenu_path;
-    const execCommand = `${dmenu_binary} ${args}`
+    const execCommand = `${dmenuPath} ${args}`
     console.debug('$', execCommand)
     const dmenu = exec(execCommand)
     dmenu.stdin.write(choices)

--- a/src/exec-dmenu.js
+++ b/src/exec-dmenu.js
@@ -3,9 +3,12 @@ const { exec } = require('child_process')
 module.exports = (...args) => choices =>
   new Promise((resolve, reject) => {
     let choice = ''
+    let dmenu_path = process.env.DMENU_PATH
     const error = []
 
-    const execCommand = `dmenu ${args}`
+    // Use a default of 'dmenu' if not specified in process.env
+    const dmenu_binary = (typeof dmenu_path === 'undefined') ? 'dmenu' : dmenu_path;
+    const execCommand = `${dmenu_binary} ${args}`
     console.debug('$', execCommand)
     const dmenu = exec(execCommand)
     dmenu.stdin.write(choices)


### PR DESCRIPTION
Allows users to configure the path to dmenu with the `DMENU_PATH` env
variable to allow support for drop-in alternatives like rofi.